### PR TITLE
Legg til ingress fra ezbrev for å kunne slå opp brevpakke-versjoner

### DIFF
--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -1,3 +1,7 @@
 ingress:
   - https://vera.intern.dev.nav.no
 mongoimage: mongo:5
+access_policy_inbound_rules:
+  - app: ezbrev-backend-q4
+    namespace: teamdokumenthandtering
+    cluster: dev-fss

--- a/nais/prod.yaml
+++ b/nais/prod.yaml
@@ -1,3 +1,7 @@
 ingress:
   - https://vera.intern.nav.no
+access_policy_inbound_rules:
+  - app: ezbrev-backend-q4
+    namespace: teamdokumenthandtering
+    cluster: dev-fss
 mongoimage: mongo:4

--- a/nais/vera.yaml
+++ b/nais/vera.yaml
@@ -12,6 +12,13 @@ spec:
     outbound:
       rules:
       - application: vera-mongo
+    inbound:
+      rules:
+    {{#each access_policy_inbound_rules}}
+      - application: {{app}}
+        namespace: {{namespace}}
+        cluster: {{cluster}}
+    {{/each}}
   liveness:
     path: /selftest
   readiness:


### PR DESCRIPTION
EzBrev er en applikasjon som brukes for å inspisere brevmaler for brev / dokumenter som blir sendt maskinelt fra NAV. Denne applikasjonen trenger å kunne querye deploylog-endepunktet for å se hvilken versjon av de forskjellige brevpakkene som er deployet til de forskjellige miljøene.